### PR TITLE
moving server creating and setup to app/server.php

### DIFF
--- a/app/server.php
+++ b/app/server.php
@@ -1,12 +1,27 @@
 <?php
 
 /**
- * Swoole server configuration.
+ * Swoole server initialization.
  *
+ * This file provides a callback for create and setup Swoole Http server.
+ * The server events will be attached later in `bin/server.php` file.
+ *
+ * @used-by ../bin/server.php
+ * @link https://openswoole.com/docs/modules/swoole-http-server-doc
  * @link https://openswoole.com/docs/modules/swoole-server/configuration
  */
 
-return [
-    'worker_num' => env('WORKER_NUM'),
-    'pid_file' => VAR_DIR . 'server.pid',
-];
+use Slim\App;
+use Swoole\Http\Server as HttpServer;
+
+return function (App $app): HttpServer {
+
+    $server = new HttpServer(env('SERVER_ADDR', 'localhost'), env('SERVER_PORT', 9501));
+
+    $server->set([
+        'worker_num' => env('WORKER_NUM'),
+        'pid_file' => VAR_DIR . 'server.pid',
+    ]);
+
+    return $server;
+};

--- a/bin/server.php
+++ b/bin/server.php
@@ -15,11 +15,7 @@ AppFactory::setContainer((function () {
 })());
 
 $app = AppFactory::create();
-
-$server = new HttpServer(env('SERVER_ADDR', 'localhost'), env('SERVER_PORT', 9501));
-$server->set((function () {
-    return include APP_DIR . 'server.php';
-})());
+$server = (require APP_DIR . 'server.php')($app);
 
 $server->on('workerStart', function (HttpServer $server) use ($app) {
 


### PR DESCRIPTION
The server will be created and initialized in `app/server.php`, before that the file only provided a configuration array but now it contains both create and configuration.

The benefit of this approach is that the server could be configured dependently in its own file, apart from that any additional customization is also allowed (for example, enabling hooks, shared table, etc). 