### PR TITLE
test cases sample loader.

### DIFF
--- a/tests/Support/SampleLoader.php
+++ b/tests/Support/SampleLoader.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Support;
+
+use JsonException;
+use RuntimeException;
+
+trait SampleLoader
+{
+    /**
+     * Loads a sample data file from the "samples" directory.
+     *
+     * @param string $filename The sample base filename.
+     * @return string
+     * @throws RuntimeException When the file cannot be read.
+     */
+    protected function loadSample(string $filename): string
+    {
+        $filepath = dirname(__DIR__) . '/samples/' . $filename;
+        if (($data = @file_get_contents($filepath)) === false) {
+            throw new RuntimeException(sprintf('Cannot load sample file "%s"', $filename));
+        }
+        return $data;
+    }
+
+    /**
+     * Loads a sample json file from the "samples" directory.
+     *
+     * @param string $filename The sample base filename (including file extension).
+     * @return mixed
+     * @throws JsonException When the sample data cannot be decoded to json.
+     */
+    protected function loadJsonSample(string $filename): mixed
+    {
+        $data = $this->loadSample($filename);
+        return json_decode($data, associative: true, flags: JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,11 +6,13 @@ use Dotenv\Dotenv;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Slim\App;
 use Slim\Factory\AppFactory;
+use Tests\Support\SampleLoader;
 use Tests\Support\SendRequest;
 
 class TestCase extends BaseTestCase
 {
     use SendRequest;
+    use SampleLoader;
 
     protected App $app;
 

--- a/tests/samples/README.md
+++ b/tests/samples/README.md
@@ -1,0 +1,14 @@
+## Samples directory
+
+Put here data sample that could be used in your test cases.
+You can load a sample data by calling the `loadSample` method
+for loading an arbitrary data or `loadJsonSample` for loading
+a json like this:
+
+```php
+    // load an arbitrary file:
+    $mySample = $this->loadSample('sample-file.txt');
+    // or load Json:
+    $jsonSample = $this->loadJsonSample('sample-file.json');
+    $jsonSample['name'] = 'anything';
+```


### PR DESCRIPTION
Provides `samples` directory where a different test samples can be located.

In a test case `loadSample` or `loadJsonSample` can be used for loading those samples. You don't need to locate a directory, checking read file error but just invoke the method with file name.
